### PR TITLE
Add recovery repo

### DIFF
--- a/recovery.xml
+++ b/recovery.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+<remote name="afstamming" fetch="https://github.com/afstamming/" />
+<remove-project name="LineageOS/android_bootable_recovery" /> -->
+<project path="bootable/recovery" name="android_bootable_recovery" remote="afstamming" revision="af-lineage-16.0" />
+</manifest>


### PR DESCRIPTION
This commit adds our own repo of recovery.
This is to fix some issues that ganges platform has with recovery.
This PR also comes with request to add the repo to this project.
Base should be lineage-16.0.
@marijnS95 Could you also include the patch in [https://github.com/sonyxperiadev/bug_tracker/issues/458](https://github.com/sonyxperiadev/bug_tracker/issues/458) please ?